### PR TITLE
Optimized request timeout config

### DIFF
--- a/events.go
+++ b/events.go
@@ -108,7 +108,7 @@ func (client *DockerClient) EventsSince(filters string, since time.Duration, unt
 			return cbErr
 		}
 		return nil
-	})
+	}, nil)
 	return events, err
 }
 

--- a/miscapis.go
+++ b/miscapis.go
@@ -80,7 +80,7 @@ type ExecConfig struct {
 
 func (client *DockerClient) Version() (Version, error) {
 	var ret Version
-	if data, err := client.sendRequest("GET", "version", nil, nil); err != nil {
+	if data, err := client.sendRequest("GET", "version", nil, nil, nil); err != nil {
 		return Version{}, err
 	} else {
 		err := json.Unmarshal(data, &ret)
@@ -161,7 +161,7 @@ func parseSwarmNodeInfo(data [][2]string) (ret SwarmNodeInfo, parseErr error) {
 
 func (client *DockerClient) Info() (DockerInfo, error) {
 	var ret DockerInfo
-	if data, err := client.sendRequest("GET", "info", nil, nil); err != nil {
+	if data, err := client.sendRequest("GET", "info", nil, nil, nil); err != nil {
 		return ret, err
 	} else {
 		err := json.Unmarshal(data, &ret)
@@ -170,7 +170,7 @@ func (client *DockerClient) Info() (DockerInfo, error) {
 }
 
 func (client *DockerClient) Ping() (bool, error) {
-	if data, err := client.sendRequest("GET", "_ping", nil, nil); err != nil {
+	if data, err := client.sendRequest("GET", "_ping", nil, nil, nil); err != nil {
 		return false, err
 	} else {
 		return string(data) == "OK", nil
@@ -182,7 +182,7 @@ func (client *DockerClient) CreateExec(id string, execConfig ExecConfig) (string
 		return "", err
 	} else {
 		uri := fmt.Sprintf("containers/%s/exec", id)
-		if data, err := client.sendRequest("POST", uri, body, nil); err != nil {
+		if data, err := client.sendRequest("POST", uri, body, nil, nil); err != nil {
 			return "", err
 		} else {
 			var ret map[string]interface{}
@@ -206,7 +206,7 @@ func (client *DockerClient) StartExec(execId string, detach, tty bool) ([]byte, 
 		return nil, err
 	} else {
 		uri := fmt.Sprintf("exec/%s/start", execId)
-		return client.sendRequest("POST", uri, body, nil)
+		return client.sendRequest("POST", uri, body, nil, nil)
 	}
 }
 

--- a/monitors.go
+++ b/monitors.go
@@ -64,7 +64,7 @@ func (client *DockerClient) monitorEvents(monitorId int64, uri string, callback 
 			client.monitorLock.RUnlock()
 		}
 		return nil
-	}, true)
+	}, nil, true)
 	if err != nil && err != io.EOF {
 		callback(Event{}, err)
 	}
@@ -96,7 +96,7 @@ func (client *DockerClient) monitorStats(monitorId int64, uri string, callback S
 			client.monitorLock.RUnlock()
 		}
 		return nil
-	}, true)
+	}, nil, true)
 	if err != nil && err != io.EOF {
 		callback(Stats{}, err)
 	}

--- a/stats.go
+++ b/stats.go
@@ -79,6 +79,6 @@ func (client *DockerClient) ContainerStats(id string) (Stats, error) {
 		decoder := json.NewDecoder(resp.Body)
 		cbErr := decoder.Decode(&stats)
 		return cbErr
-	})
+	}, nil)
 	return stats, err
 }


### PR DESCRIPTION
Most docker request should not be with non timeout except monitor request. 
When network is unstable, operation could be blocked and couldn't exec any new operation in the same goroutine.
So implement a mechanical "add extra timeout like 'pull image', 'stop/restart container' for docker operation based on normal api call timeout", which would make docker request operation more graceful.